### PR TITLE
Add a manual mode and keymapping

### DIFF
--- a/keymaps/zentabs.cson
+++ b/keymaps/zentabs.cson
@@ -1,0 +1,2 @@
+'.workspace':
+  'ctrl-Z': 'zentabs:cleanup'

--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -5,10 +5,12 @@ module.exports =
 class ZentabsController extends View
 
   @content: ()->
-    @div =>
-      @h1 'ZenTabs'
+    @span ''
 
   initialize: (@pane) ->
+
+    atom.workspaceView.command 'zentabs:cleanup', => @closeOverflowingTabs()
+
     @items = []
     @subscriptions = []
     @paneContainer = @pane.getContainer()
@@ -31,9 +33,11 @@ class ZentabsController extends View
 
     @updateActiveTab()
 
+    atom.workspaceView.append(this)
+
   pushItem: (item)->
     @items.push item
-    @closeOverflowingTabs()
+    @closeOverflowingTabs() unless atom.config.get 'zentabs.manualMode'
 
   updateActiveTab: ->
     return unless @pane.activeItem

--- a/lib/zentabs.coffee
+++ b/lib/zentabs.coffee
@@ -5,6 +5,7 @@ module.exports =
 
   configDefaults:
     maximumOpenedTabs: 5
+    manualMode: false
 
   activate: ->
     @paneSubscription = atom.workspaceView.eachPane (pane) =>

--- a/spec/zentabs-spec.coffee
+++ b/spec/zentabs-spec.coffee
@@ -56,3 +56,45 @@ describe "Zentabs", ->
       item5 = new TestView('Item 5')
       pane.addItem(item5, 0)
       expect(pane.getItems().indexOf(item2)).toEqual -1
+
+  describe "When manual mode is enabled", ->
+    beforeEach ()->
+      atom.config.set 'zentabs.manualMode', true
+      atom.config.set 'zentabs.maximumOpenedTabs', 4
+
+      item3 = new TestView('Item 3')
+      item4 = new TestView('Item 4')
+
+      pane.addItem(item3, 0)
+      pane.addItem(item4, 0)
+
+    afterEach ()->
+      atom.config.set 'zentabs.manualMode', false
+      atom.config.set 'zentabs.maximumOpenedTabs', null
+
+    it "does not limits the number of opened tabs", ->
+      expect(pane.getItems().length).toEqual 4
+      item5 = new TestView('Item 5')
+      pane.addItem(item5, 0)
+      expect(pane.getItems().length).toEqual 5
+
+  describe "When zentabs:cleanup is fired", ->
+    beforeEach ()->
+      atom.config.set 'zentabs.manualMode', true
+      atom.config.set 'zentabs.maximumOpenedTabs', 4
+      item3 = new TestView('Item 3')
+      item4 = new TestView('Item 4')
+      item5 = new TestView('Item 5')
+
+      pane.addItem(item3, 0)
+      pane.addItem(item4, 0)
+      pane.addItem(item5, 0)
+
+    afterEach ()->
+      atom.config.set 'zentabs.manualMode', false
+      atom.config.set 'zentabs.maximumOpenedTabs', null
+
+    it "trigger a cleanup", ->
+      expect(pane.getItems().length).toEqual 5
+      atom.workspaceView.trigger 'zentabs:cleanup'
+      expect(pane.getItems().length).toEqual 4


### PR DESCRIPTION
This branch adds a manual mode (default: off) to disable automatic tab closing.

It also adds a shortcut to manually trigger the tab cleanup.
