### PR TITLE
Remove deprecation warnings

### DIFF
--- a/keymaps/zentabs.cson
+++ b/keymaps/zentabs.cson
@@ -1,2 +1,2 @@
-'.workspace':
+'atom-workspace':
   'ctrl-Z': 'zentabs:cleanup'

--- a/menus/zentabs.cson
+++ b/menus/zentabs.cson
@@ -1,5 +1,8 @@
 'context-menu':
-  '.tab:not(.pinned)':
-    'Pin tab': 'zentabs:pintab'
-  '.tab.pinned':
-    'Unpin tab': 'zentabs:unpintab'
+  '.tab:not(.pinned)': [
+    {label: 'Pin tab', command: 'zentabs:pintab'}
+  ]
+  
+  '.tab.pinned': [
+    {label: 'Unpin tab', command: 'zentabs:unpintab'}
+  ]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "license": "MIT",
   "repository": "https://github.com/ArnaudRinquin/atom-zentabs",
   "engines": {
-    "atom": "*"
+    "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x"
+    "underscore-plus": "1.x",
+    "atom-space-pen-views": "^2.0.3"
   }
 }

--- a/spec/zentabs-spec.coffee
+++ b/spec/zentabs-spec.coffee
@@ -1,8 +1,9 @@
-{$, WorkspaceView, View}  = require 'atom'
+{Disposable} = require 'atom'
+{$,View} = require 'atom-space-pen-views'
 ZentabsController = require '../lib/zentabs-controller'
 
 describe "Zentabs", ->
-  [item1, item2, item3, item4, pane] = []
+  [workspaceElement, item1, item2, item3, item4, pane] = []
 
   class TestView extends View
     @deserialize: ({title, longTitle}) -> new TestView(title, longTitle)
@@ -11,13 +12,15 @@ describe "Zentabs", ->
     getTitle: -> @title
     getLongTitle: -> @longTitle
     serialize: -> { deserializer: 'TestView', @title, @longTitle }
+    onDidChangeTitle: -> new Disposable
+    onDidChangeModified: -> new Disposable
+
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-    atom.deserializers.add(TestView)
+    workspaceElement = atom.views.getView(atom.workspace)
     item1 = new TestView('Item 1')
     item2 = new TestView('Item 2')
-    pane = atom.workspaceView.getActivePaneView()
+    pane = atom.workspace.getActivePane()
     pane.addItem(item1, 0)
     pane.addItem(item2, 2)
     pane.activateItem(item2)
@@ -25,8 +28,6 @@ describe "Zentabs", ->
     waitsForPromise ->
       atom.packages.activatePackage("zentabs")
 
-  afterEach ->
-    atom.deserializers.remove(TestView)
 
   describe "When a maximum tab limit is set", ->
     beforeEach ()->
@@ -96,5 +97,5 @@ describe "Zentabs", ->
 
     it "trigger a cleanup", ->
       expect(pane.getItems().length).toEqual 5
-      atom.workspaceView.trigger 'zentabs:cleanup'
+      atom.commands.dispatch workspaceElement, 'zentabs:cleanup'
       expect(pane.getItems().length).toEqual 4


### PR DESCRIPTION
This commit replaces some API calls with 1.0 API to remove deprecation warnings as instructed in following guide.
https://atom.io/docs/latest/upgrading/upgrading-your-package

This changes will close #14 and #15.