### PR TITLE
Don't add controller as a panel

### DIFF
--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -39,8 +39,6 @@ class ZentabsController extends View
     @updateActiveTab()
     @closeOverflowingTabs() unless atom.config.get 'zentabs.manualMode'
 
-    atom.workspace.addBottomPanel(item: this)
-
   destroy: =>
     @subscriptions.dispose()
 


### PR DESCRIPTION
Adding the controller as a panel creates an empty visible panel element on the workspace, which shows as a thin black bar (with the dark theme) above the status bar. It creates a new panel for each pane split and never removes them.

As far as I can see there's no need to actually add the controller to the DOM at all. In fact it shouldn't really be a space pen view, thinking about it.