### PR TITLE
Skip null repositories

### DIFF
--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -70,6 +70,7 @@ class ZentabsController extends View
 
         if itemPath = olderItem.buffer?.file?.path
           @getRepositories().forEach (repo)->
+            return unless repo
             preventBecauseDirty = preventBecauseDirty || repo.isPathModified(itemPath) && neverCloseDirty
             preventBecauseNew = preventBecauseNew || repo.isPathNew(itemPath) && neverCloseNew
 


### PR DESCRIPTION
`atom.project.getRepositories()` returns an array with an element for each project root, regardless of whether that root has a repository. So sometimes the returned array contains some `null`s.