### PR TITLE
Skip null repositories

### DIFF
--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -69,7 +69,8 @@ class ZentabsController extends View
         preventBecauseNew = false
 
         if itemPath = olderItem.buffer?.file?.path
-          @getRepositories().forEach (repo)->
+          @getRepositories().forEach (repo) ->
+            return unless repo
             preventBecauseDirty = preventBecauseDirty || repo.isPathModified(itemPath) && neverCloseDirty
             preventBecauseNew = preventBecauseNew || repo.isPathNew(itemPath) && neverCloseNew
 


### PR DESCRIPTION
Accidentally deleted my branch for #22, here it is again.

`atom.project.getRepositories()` returns an array with an element for each project root, regardless of whether that root has a repository. So sometimes the returned array contains some `null`s.