### PR TITLE
Toggle pinned tab command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -14,6 +14,7 @@ class ZentabsController extends View
     @subscriptions.add atom.commands.add 'atom-workspace', 'zentabs:cleanup', => @closeOverflowingTabs()
     @subscriptions.add atom.commands.add 'atom-workspace', 'zentabs:pintab', @pinTab
     @subscriptions.add atom.commands.add 'atom-workspace', 'zentabs:unpintab', @unpinTab
+    @subscriptions.add atom.commands.add 'atom-workspace', 'zentabs:toggletab', @toggleTab
 
     @items = []
     @pinnedItems = []
@@ -107,3 +108,18 @@ class ZentabsController extends View
     # tab.find('.title').removeClass 'icon icon-lock'
 
     @closeOverflowingTabs()
+
+  toggleTab: =>
+    tab = $('.tab.active')
+    return unless tab
+
+    view = atom.views.getView tab
+    item = view.item
+    if tab.hasClass('pinned')
+      @pushItem item
+      tab.removeClass 'pinned'
+      @closeOverflowingTabs()
+    else
+      _.remove @items, item
+      @pinnedItems.push item unless @pinnedItems.indexOf(item) > -1
+      tab.addClass 'pinned'

--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -65,7 +65,7 @@ class ZentabsController extends View
     tmpItems.forEach (olderItem) =>
       if @items.length > maxTabs
         # Check tab saved status
-        preventBecauseUnsaved = olderItem.buffer?.isModified() && neverCloseUnsaved;
+        preventBecauseUnsaved = olderItem.buffer?.isModified() && neverCloseUnsaved
         preventBecauseDirty = false
         preventBecauseNew = false
 


### PR DESCRIPTION
As described in #29; added a `zentab:togglepin` command which toggles pinned state on the active views tab. This is especially helpfull when binding keyboard shortcuts e.g.:

```js
'atom-workspace':
  'cmd-b': 'zentabs:toggletab'
```