### PR TITLE
Fix Zentab pin/unpin command usage without mouse

### DIFF
--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -80,8 +80,8 @@ class ZentabsController extends View
           @pane.destroyItem olderItem
 
   pinTab: () =>
-    tab = $('.tab.right-clicked')
-    return unless tab
+    tab = $('.tab.right-clicked, .tab.active').first()
+    return if tab.size() is 0
 
     view = atom.views.getView tab
     item = view.item
@@ -94,8 +94,8 @@ class ZentabsController extends View
     # tab.find('.title').addClass 'icon icon-lock' if atom.config.get 'zentabs.showPinnedIcon'
 
   unpinTab: (event) =>
-    tab = $('.tab.right-clicked')
-    return unless tab
+    tab = $('.tab.right-clicked, .tab.active').first()
+    return if tab.size() is 0
 
     view = atom.views.getView tab
     item = view.item


### PR DESCRIPTION
There is no tab with 'right-clicked' class when you use
these commands from the command palette. The best solution for this issue
is to apply this command on 'right-clicked' tab when it's available
and just use the active tab as fallback.

Fixes #38.