### PR TITLE
Fix Pin/Unpin Tab commands.

### DIFF
--- a/lib/zentabs-controller.coffee
+++ b/lib/zentabs-controller.coffee
@@ -80,7 +80,7 @@ class ZentabsController extends View
           @pane.destroyItem olderItem
 
   pinTab: () =>
-    tab = $('.tab.right-clicked, .tab.active').first()
+    tab = $('.tab.right-clicked').first()
     return if tab.size() is 0
 
     view = atom.views.getView tab
@@ -94,7 +94,7 @@ class ZentabsController extends View
     # tab.find('.title').addClass 'icon icon-lock' if atom.config.get 'zentabs.showPinnedIcon'
 
   unpinTab: (event) =>
-    tab = $('.tab.right-clicked, .tab.active').first()
+    tab = $('.tab.right-clicked').first()
     return if tab.size() is 0
 
     view = atom.views.getView tab


### PR DESCRIPTION
Use only '.tab.right-clicked' selector, because '.tab.right-clicked, .tab-active' now selects the Projects tab first.

Fixes #43 